### PR TITLE
Update default YT-DLP version to 2025.10.14

### DIFF
--- a/src/lib/yt-dlp.ts
+++ b/src/lib/yt-dlp.ts
@@ -7,7 +7,7 @@ const ytDlpPath = path.resolve('./yt-dlp');
 const outputDir = path.resolve('./temp');
 
 export async function ensureYtDlpBinary() {
-  const ytDlpVersion = process.env.YT_DLP_VERSION || '2025.05.22';
+  const ytDlpVersion = process.env.YT_DLP_VERSION || '2025.10.14';
   const exists = await fs
       .access(ytDlpPath)
       .then(() => true)


### PR DESCRIPTION
This pull request updates the default version of the `yt-dlp` binary used by the application. The change ensures that, unless otherwise specified by the `YT_DLP_VERSION` environment variable, the application will use a newer version of `yt-dlp`.

- Updated the default `yt-dlp` version from `2025.05.22` to `2025.10.14` in `src/lib/yt-dlp.ts`