### PR TITLE
fix: :bug: EXTRA_PROMPT was ignored due to the refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Other sites may work as well, since the tool uses `yt-dlp` to download videos. I
                 - MEALIE_API_KEY=${MEALIE_API_KEY}
                 # Optional, Mealie group name, defaults to "home"
                 - MEALIE_GROUP_NAME=home
-                # Optional, customize the standard prompt if needed this will replace it
-                - USER_PROMPT=Custom prompt
                 # Optional, addition to the prompt, useful for translation needs
                 - EXTRA_PROMPT=The description, ingredients, and instructions must be provided in Spanish
             ports:
@@ -84,7 +82,6 @@ docker run --restart unless-stopped --name social-to-mealie \
   -e MEALIE_URL=https://mealie.example.com \
   -e MEALIE_API_KEY=ey... \
   -e MEALIE_GROUP_NAME=home \
-  -e USER_PROMPT="Custom prompt" \
   -e EXTRA_PROMPT="The description, ingredients, and instructions must be provided in Spanish" \
   -p 4000:3000 \
   --security-opt no-new-privileges:true \

--- a/src/app/api/get-url/route.ts
+++ b/src/app/api/get-url/route.ts
@@ -5,6 +5,7 @@ import {
     getTranscription,
     refineRecipeWithAI,
 } from "@/lib/ai"; // Import new AI functions
+import { env } from "@/lib/constants";
 import { downloadMediaWithYtDlp } from "@/lib/yt-dlp";
 
 interface RequestBody {
@@ -53,7 +54,8 @@ async function handleRequest(
             transcription,
             socialMediaResult.description,
             url, // Use the original URL for postURL
-            socialMediaResult.thumbnail
+            socialMediaResult.thumbnail,
+            env.EXTRA_PROMPT || ""
         );
 
         if (isSse && controller) {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -34,7 +34,8 @@ export async function generateRecipeFromAI(
     transcription: string,
     description: string,
     postURL: string,
-    thumbnail: string
+    thumbnail: string,
+    extraPrompt: string
 ) {
     const schema = z.object({
         "@context": z
@@ -74,6 +75,12 @@ export async function generateRecipeFromAI(
         Use the thumbnail for the image field and the post URL for the url field.
         Extract ingredients and instructions clearly.
         Output must be valid JSON-LD Schema.org Recipe format.
+        ${
+            extraPrompt.length > 1
+                ? ` Also the user requests that:
+        ${extraPrompt}`
+                : ""
+        }
       `,
         });
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,4 +18,5 @@ export const env: envTypes = {
         process.env.FFMPEG_PATH?.trim() || ("/usr/bin/ffmpeg" as string),
     YTDLP_PATH:
         process.env.YTDLP_PATH?.trim() || ("/usr/local/bin/yt-dlp" as string),
+    EXTRA_PROMPT: process.env.EXTRA_PROMPT?.trim() || ("" as string),
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export type envTypes = {
     MEALIE_GROUP_NAME: string;
     FFMPEG_PATH: string;
     YTDLP_PATH: string;
+    EXTRA_PROMPT: string;
 };
 
 export type recipeResult = {


### PR DESCRIPTION
This pull request introduces support for passing a custom extra prompt to the AI recipe generation process, allowing for more flexible and user-specific recipe outputs (such as translations or additional instructions). The changes update the environment variable handling, propagate the extra prompt through the backend API, and integrate it into the AI prompt construction.

**Environment variable and configuration updates:**

* Added `EXTRA_PROMPT` as a supported environment variable in `src/lib/constants.ts` and updated its type definition in `src/lib/types.ts`. This enables configuration of custom instructions for recipe generation. [[1]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR21) [[2]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R18)
* Updated documentation in `README.md` to remove the deprecated `USER_PROMPT` variable and clarify usage of `EXTRA_PROMPT`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-L54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87)

**Backend logic and AI integration:**

* Modified the API route in `src/app/api/get-url/route.ts` to pass the `EXTRA_PROMPT` value from the environment to the AI recipe generation function. [[1]](diffhunk://#diff-f12a78e8dc64776dc75247d683bee91d4b8af018e732ccba7047b013c0ad9e70R8) [[2]](diffhunk://#diff-f12a78e8dc64776dc75247d683bee91d4b8af018e732ccba7047b013c0ad9e70L56-R58)
* Updated `generateRecipeFromAI` in `src/lib/ai.ts` to accept and incorporate `extraPrompt` into the AI prompt, ensuring that custom instructions are included in the generated recipe output. [[1]](diffhunk://#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95L37-R38) [[2]](diffhunk://#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95R78-R83)