### PR TITLE
fix(docker-compose): add local build config and env var substitution with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD041 -->
 
 <p align="center">
 <img width="150" src="./public/android-chrome-512x512.png" alt="logo" />
@@ -43,15 +45,16 @@ websites, please open an issue.
 <details open>
     <summary>Docker Compose</summary>
 
-1. Create a `docker-compose.yml` file based on
-   the [example](https://github.com/GerardPolloRebozado/social-to-mealie/blob/main/docker-compose.yml) in the repo and
-   fill in the required environment variables, if you prefer having them in a separate file you can create a `.env` file
-   based on the [example.env](https://github.com/GerardPolloRebozado/social-to-mealie/blob/main/example.env).
+1. Create a `docker-compose.yml` file based on the [docker-compose.example.yml](https://github.com/GerardPolloRebozado/social-to-mealie/blob/main/docker-compose.example.yml)
+   in the repo and fill in the required environment variables.
+   If you prefer having them in a separate file you can create a `.env` file based on the [example.env](https://github.com/GerardPolloRebozado/social-to-mealie/blob/main/example.env).
 
 2. **Start the service with Docker Compose:**
+
     ```sh
     docker-compose up -d
     ```
+
     </details>
 
 <details>
@@ -76,22 +79,27 @@ docker run --restart unless-stopped --name social-to-mealie \
     <summary>Local Development</summary>
 
 1. Clone the repository and install dependencies:
+
     ```sh
     git clone https://github.com/GerardPolloRebozado/social-to-mealie.git
     cd social-to-mealie
+    npm install
     ```
 
 2. Create a `.env` file based on `example.env` and fill in your values:
+
     ```sh
     cp example.env .env
     ```
 
-3. Create an empty `cookies.txt` file (required by the volume mount even if unused):
+3. Create an empty `cookies.txt` file (required by the volume mount if defined in `docker-compose.yml`):
+
     ```sh
     touch cookies.txt
     ```
 
 4. Build and start the container locally:
+
     ```sh
     docker compose build
     docker compose up -d
@@ -100,38 +108,44 @@ docker run --restart unless-stopped --name social-to-mealie \
     The app will be available at `http://localhost:4000`.
 
 5. To view logs:
+
     ```sh
     docker logs -f social-to-mealie
     ```
 
 </details>
 
-3. In order to be able to install the PWA the app needs to have HTTPS, you can use a reverse proxy like caddy or nginx, but be careful as opening this app to the internet as it will allow anyone to submit recipes to your Mealie instance. I recommend adding a small log in or IP whitelist
+> [!TIP]
+> In order to be able to install the PWA the app needs to have HTTPS, you can use a reverse proxy like caddy or nginx,
+> but be careful as opening this app to the internet as it will allow anyone to submit recipes to your Mealie instance.
+> I recommend adding a small log in or IP whitelist
 
 ## Environment Variables
 
-| Variable                  | Required | Description                                                                                                                            |
-| ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| OPENAI_URL                | Yes      | URL for the OpenAI API or a compatible one                                                                                             |
-| OPENAI_API_KEY            | Yes      | API key for OpenAI or a compatible one                                                                                                 |
-| TRANSCRIPTION_MODEL       | No       | Whisper model to use, required when the local one is not filled                                                                        |
-| LOCAL_TRANSCRIPTION_MODEL | No       | Model ID from hugging face to use for local audio to text transcription, required when the provider doesn't support transcriptions API |
-| TEXT_MODEL                | Yes      | Text model to use for recipe generation                                                                                                |
-| MEALIE_URL                | Yes      | URL of your Mealie instance                                                                                                            |
-| MEALIE_API_KEY            | Yes      | API key for Mealie                                                                                                                     |
-| MEALIE_GROUP_NAME         | No       | Mealie group name, defaults to "home"                                                                                                  |
-| EXTRA_PROMPT              | No       | Additional instructions for AI, such as language translation                                                                           |
-| YTDLP_VERSION             | No       | Version of yt-dlp to use, defaults to latest                                                                                           |
-| PORT                      | No       | Host port to expose the app on, defaults to 4000                                                                                       |
-| COOKIES                   | No       | Cookies string for yt-dlp to access protected content `NAME=VALUE`                                                                     |
+| Variable                  | Required | Default                     | Description                                                                                                                            |
+| ------------------------- | -------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| OPENAI_URL                | Yes      | `https://api.openai.com/v1` | URL for the OpenAI API or a compatible one                                                                                             |
+| OPENAI_API_KEY            | Yes      | —                           | API key for OpenAI or a compatible one                                                                                                 |
+| TRANSCRIPTION_MODEL       | No       | `whisper-1`                 | Whisper model to use, required when the local one is not filled                                                                        |
+| LOCAL_TRANSCRIPTION_MODEL | No       | —                           | Model ID from hugging face to use for local audio to text transcription, required when the provider doesn't support transcriptions API |
+| TEXT_MODEL                | Yes      | `gpt-5-mini`                | Text model to use for recipe generation                                                                                                |
+| MEALIE_URL                | Yes      | `http://localhost:9000`     | URL of your Mealie instance                                                                                                            |
+| MEALIE_API_KEY            | Yes      | —                           | API key for Mealie                                                                                                                     |
+| MEALIE_GROUP_NAME         | No       | `home`                      | Mealie group name                                                                                                                      |
+| EXTRA_PROMPT              | No       | —                           | Additional instructions for AI, such as language translation                                                                           |
+| YTDLP_VERSION             | No       | `latest`                    | Version of yt-dlp to use                                                                                                               |
+| PORT                      | No       | `4000`                      | Host port to expose the app on                                                                                                         |
+| COOKIES                   | No       | —                           | Cookies string for yt-dlp to access protected content `NAME=VALUE`                                                                     |
 
-## Tested AI providers compatibility:
+## Tested AI providers compatibility
 
 - OpenAI
 - GroqAI
 
-## Partial support:
+## Partial support
+
 Because theese providers don't support the transcriptions API it requires LOCAL_TRANSCRIPTION_MODEL to be set, recommended model: `Xenova/whisper-base`, you can use any model that is compatible with the ONNX runtime from hugging face
+
 - llmstudio
 - ollama
 
@@ -144,7 +158,5 @@ If you want to use another model the model needs to have tools support and visio
 If you want better results use the same models but in larger variants.
 
 It can work with any other provider that is compatible with the OpenAI API, if you find any issues please open an issue.
-
-
 
 [![Star History Chart](https://app.repohistory.com/api/svg?repo=GerardPolloRebozado/social-to-mealie&type=Date&background=0D1117&color=f86262)](https://app.repohistory.com/star-history)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<!-- markdownlint-disable MD033 -->
-<!-- markdownlint-disable MD041 -->
-
 <p align="center">
 <img width="150" src="./public/android-chrome-512x512.png" alt="logo" />
 </p>

--- a/README.md
+++ b/README.md
@@ -72,12 +72,46 @@ docker run --restart unless-stopped --name social-to-mealie \
 
 </details>
 
+<details>
+    <summary>Local Development</summary>
+
+1. Clone the repository and install dependencies:
+    ```sh
+    git clone https://github.com/GerardPolloRebozado/social-to-mealie.git
+    cd social-to-mealie
+    ```
+
+2. Create a `.env` file based on `example.env` and fill in your values:
+    ```sh
+    cp example.env .env
+    ```
+
+3. Create an empty `cookies.txt` file (required by the volume mount even if unused):
+    ```sh
+    touch cookies.txt
+    ```
+
+4. Build and start the container locally:
+    ```sh
+    docker compose build
+    docker compose up -d
+    ```
+
+    The app will be available at `http://localhost:4000`.
+
+5. To view logs:
+    ```sh
+    docker logs -f social-to-mealie
+    ```
+
+</details>
+
 3. In order to be able to install the PWA the app needs to have HTTPS, you can use a reverse proxy like caddy or nginx, but be careful as opening this app to the internet as it will allow anyone to submit recipes to your Mealie instance. I recommend adding a small log in or IP whitelist
 
 ## Environment Variables
 
 | Variable                  | Required | Description                                                                                                                            |
-|---------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | OPENAI_URL                | Yes      | URL for the OpenAI API or a compatible one                                                                                             |
 | OPENAI_API_KEY            | Yes      | API key for OpenAI or a compatible one                                                                                                 |
 | TRANSCRIPTION_MODEL       | No       | Whisper model to use, required when the local one is not filled                                                                        |
@@ -88,6 +122,7 @@ docker run --restart unless-stopped --name social-to-mealie \
 | MEALIE_GROUP_NAME         | No       | Mealie group name, defaults to "home"                                                                                                  |
 | EXTRA_PROMPT              | No       | Additional instructions for AI, such as language translation                                                                           |
 | YTDLP_VERSION             | No       | Version of yt-dlp to use, defaults to latest                                                                                           |
+| PORT                      | No       | Host port to expose the app on, defaults to 4000                                                                                       |
 | COOKIES                   | No       | Cookies string for yt-dlp to access protected content `NAME=VALUE`                                                                     |
 
 ## Tested AI providers compatibility:
@@ -97,7 +132,7 @@ docker run --restart unless-stopped --name social-to-mealie \
 
 ## Partial support:
 Because theese providers don't support the transcriptions API it requires LOCAL_TRANSCRIPTION_MODEL to be set, recommended model: `Xenova/whisper-base`, you can use any model that is compatible with the ONNX runtime from hugging face
-- llmstudio 
+- llmstudio
 - ollama
 
 Some recommended models for local AI are:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,26 @@
+services:
+  social-to-mealie:
+    restart: unless-stopped
+    image: ghcr.io/gerardpollorebozado/social-to-mealie:latest
+    container_name: social-to-mealie
+    environment:
+      - OPENAI_URL=https://api.openai.com/v1 #URL of an OPENAI api compatible provider
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - TRANSCRIPTION_MODEL=whisper-1 # this model will be used to transcribe the audio to text
+      - TEXT_MODEL=model # the model you want to use to create the recipe in json using the transcription result
+      - MEALIE_URL=https://mealie.example.com # url of you mealie instance
+      - MEALIE_API_KEY=${MEALIE_API_KEY}
+      # Optionally specify yt-dlp version to use. Use "latest" or a release tag like "2025.11.01".
+      # If provided, the container will try to download yt-dlp at startup
+      - YTDLP_VERSION=latest
+      # Optional, Mealie group name, defaults to "home"
+      - MEALIE_GROUP_NAME=home
+      # Optional, addition to the prompt, useful for translation needs remove if not needed
+      - EXTRA_PROMPT=The description, ingredients, and instructions must be provided in Spanish
+      - COOKIES= #Optional, cookie for yt-dlp requests, useful for protected content
+    volumes:
+      - ./cookies.txt:/app/cookies.txt # Optional, only needed for some content
+    ports:
+      - 4000:3000
+    security_opt:
+      - no-new-privileges:true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,6 @@ services:
     volumes:
       - ./cookies.txt:/app/cookies.txt # Optional, only needed for some content
     ports:
-      - 4000:3000
+      - ${PORT:-4000}:3000
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       - MEALIE_API_KEY=${MEALIE_API_KEY}
       # Optionally specify yt-dlp version to use. Use "latest" or a release tag like "2025.11.01".
       # If provided, the container will try to download yt-dlp at startup
-      - YTDLP_VERSION=latest
+      - YTDLP_VERSION=${YTDLP_VERSION:-latest}
       # Optional, Mealie group name, defaults to "home"
-      - MEALIE_GROUP_NAME=home
+      - MEALIE_GROUP_NAME=${MEALIE_GROUP_NAME:-home}
       # Optional, addition to the prompt, useful for translation needs remove if not needed
-      - EXTRA_PROMPT=The description, ingredients, and instructions must be provided in Spanish
-      - COOKIES= #Optional, cookie for yt-dlp requests, useful for protected content
+      - EXTRA_PROMPT=${EXTRA_PROMPT:-}
+      - COOKIES=${COOKIES:-} #Optional, cookie for yt-dlp requests, useful for protected content
     volumes:
       - ./cookies.txt:/app/cookies.txt # Optional, only needed for some content
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,17 @@
 services:
   social-to-mealie:
     restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ghcr.io/gerardpollorebozado/social-to-mealie:latest
     container_name: social-to-mealie
     environment:
-      - OPENAI_URL=https://api.openai.com/v1 #URL of an OPENAI api compatible provider
+      - OPENAI_URL=${OPENAI_URL:-https://api.openai.com/v1} #URL of an OPENAI api compatible provider
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - TRANSCRIPTION_MODEL=whisper-1 # this model will be used to transcribe the audio to text
-      - TEXT_MODEL=model # the model you want to use to create the recipe in json using the transcription result
-      - MEALIE_URL=https://mealie.example.com # url of you mealie instance
+      - TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-whisper-1} # this model will be used to transcribe the audio to text
+      - TEXT_MODEL=${TEXT_MODEL:-gpt-5-mini} # the model you want to use to create the recipe in json using the transcription result
+      - MEALIE_URL=${MEALIE_URL:-http://localhost:9000} # url of you mealie instance
       - MEALIE_API_KEY=${MEALIE_API_KEY}
       # Optionally specify yt-dlp version to use. Use "latest" or a release tag like "2025.11.01".
       # If provided, the container will try to download yt-dlp at startup

--- a/example.env
+++ b/example.env
@@ -11,3 +11,4 @@ MEALIE_GROUP_NAME=home # Optional, Mealie group name, defaults to "home"
 EXTRA_PROMPT= # here you can type instructions for the model like for example unit conversion or translations, remove this if not used
 COOKIES="NAME=VALUE" #Optional, cookies for yt-dlp requests, useful for protected content
 LOCAL_TRANSCRIPTION_MODEL=Xenova/whisper-base
+PORT=4000 # Optional, port to expose the app on, defaults to 4000


### PR DESCRIPTION
- Add build context pointing to local Dockerfile to support 'docker compose build'
- Replace hardcoded OPENAI_URL, TRANSCRIPTION_MODEL, TEXT_MODEL, and MEALIE_URL values with env var substitution using ${VAR:-default} syntax
- Fix placeholder TEXT_MODEL value ('model') to use gpt-5-mini as default
- Fix placeholder MEALIE_URL to use localhost:9000 as default
- Add local development section to README with step-by-step instructions
  for building and running the container locally via docker compose
- Make host port configurable via PORT env var with a default of 4000