### PR TITLE
fix(route): guard against empty media extraction before invoking AI

### DIFF
--- a/src/app/api/get-url/route.ts
+++ b/src/app/api/get-url/route.ts
@@ -31,6 +31,16 @@ async function handleRequest(
             );
         }
         socialMediaResult = await downloadMediaWithYtDlp(url);
+
+        const hasUsableContent =
+            socialMediaResult.blob ||
+            (socialMediaResult.images && socialMediaResult.images.length > 0) ||
+            (socialMediaResult.thumbnail && socialMediaResult.thumbnail !== "notfound");
+
+        if (!hasUsableContent) {
+            throw new Error("Could not extract any media or metadata from the provided URL");
+        }
+
         progress.videoDownloaded = true;
 
         if (isSse && controller) {


### PR DESCRIPTION
Without this check, when both yt-dlp and gallery-dl fail to retrieve any usable content from a URL (e.g. due to a network error, rate-limiting, or unsupported platform), the pipeline silently proceeds with empty data:
- blob: null
- thumbnail: 'notfound'
- images: []

The AI then receives no transcription, no thumbnail and no images, but still generates a plausible-sounding recipe filled with placeholder text. That recipe is subsequently posted to Mealie, polluting the user's library with entries like 'Receta no disponible — transcripcion faltante' that require manual cleanup.

The fix validates that at least one of blob, images, or a real thumbnail was extracted before proceeding. If none are present, a clear error is thrown and surfaced to the client, with the progress state set to failed, so the user knows the download step itself went wrong rather than receiving a silently incorrect recipe.